### PR TITLE
Fix buffered messages when no clients.

### DIFF
--- a/src/main/java/org/gridsuite/merge/notification/server/MergeNotificationWebSocketHandler.java
+++ b/src/main/java/org/gridsuite/merge/notification/server/MergeNotificationWebSocketHandler.java
@@ -71,6 +71,10 @@ public class MergeNotificationWebSocketHandler implements WebSocketHandler {
             ConnectableFlux<Message<String>> c = f.log(CATEGORY_BROKER_INPUT, Level.FINE).publish();
             this.flux = c;
             c.connect();
+            // Force connect 1 fake subscriber to consumme messages as they come.
+            // Otherwise, reactorcore buffers some messages (not until the connectable flux had
+            // at least one subscriber. Is there a better way ?
+            c.subscribe();
         };
     }
 

--- a/src/test/java/org/gridsuite/merge/notification/server/MergeNotificationWebSocketHandlerTest.java
+++ b/src/test/java/org/gridsuite/merge/notification/server/MergeNotificationWebSocketHandlerTest.java
@@ -21,12 +21,14 @@ import org.springframework.web.reactive.socket.HandshakeInfo;
 import org.springframework.web.reactive.socket.WebSocketMessage;
 import org.springframework.web.reactive.socket.WebSocketSession;
 import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
 
 import java.io.UncheckedIOException;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +38,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -147,4 +150,44 @@ public class MergeNotificationWebSocketHandlerTest {
         assertEquals("testsession-0", argument.getValue().blockFirst(Duration.ofSeconds(10)).getPayloadAsText());
     }
 
+    @Test
+    public void testDiscard() {
+        var notificationWebSocketHandler = new MergeNotificationWebSocketHandler(objectMapper, Integer.MAX_VALUE);
+
+        UriComponentsBuilder uriComponentBuilder = UriComponentsBuilder.fromUriString("http://localhost:1234/notify");
+
+        when(handshakeinfo.getUri()).thenReturn(uriComponentBuilder.build().toUri());
+
+        var atomicRef = new AtomicReference<FluxSink<Message<String>>>();
+        var flux = Flux.create(atomicRef::set);
+        notificationWebSocketHandler.consumeNotification().accept(flux);
+        var sink = atomicRef.get();
+        Map<String, Object> headers = Map.of("process", "SWE", "date", "2020-07-01 02:30:00.000000+0000", "tso", "RTE", "type", "TEST");
+
+        sink.next(new GenericMessage<String>("", headers)); // should be discarded, no client connected
+
+        notificationWebSocketHandler.handle(ws);
+
+        ArgumentCaptor<Flux<WebSocketMessage>> argument1 = ArgumentCaptor.forClass(Flux.class);
+        verify(ws).send(argument1.capture());
+        List<String> messages1 = new ArrayList<String>();
+        Flux<WebSocketMessage> out1 = argument1.getValue();
+        Disposable d1 = out1.map(WebSocketMessage::getPayloadAsText).subscribe(messages1::add);
+        d1.dispose();
+
+        sink.next(new GenericMessage<String>("", headers)); // should be discarded, first client disconnected
+
+        notificationWebSocketHandler.handle(ws);
+
+        ArgumentCaptor<Flux<WebSocketMessage>> argument2 = ArgumentCaptor.forClass(Flux.class);
+        verify(ws, times(2)).send(argument2.capture());
+        List<String> messages2 = new ArrayList<String>();
+        Flux<WebSocketMessage> out2 = argument2.getValue();
+        Disposable d2 = out1.map(WebSocketMessage::getPayloadAsText).subscribe(messages1::add);
+        d2.dispose();
+
+        sink.complete();
+        assertEquals(0, messages1.size());
+        assertEquals(0, messages2.size());
+    }
 }


### PR DESCRIPTION
We want to discard them, not replay them on the next connected client

Signed-off-by: Jon Harper <jon.harper87@gmail.com>